### PR TITLE
chore: verify build -- Microsoft.Extensions 10.0.11

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,3 +17,5 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 </Project>
+
+<!-- verify-build: Microsoft.Extensions 10.0.11 + Test.Sdk 18.9.0 -->


### PR DESCRIPTION
Verifica que todo compila tras bumps a 10.0.11 + Test.Sdk 18.9.0

- Build Release OK
- Tests 50 passed
- Cambios: Microsoft.Extensions.* 9.0.19 -> 10.0.11, Microsoft.NET.Test.Sdk 18.8.1 -> 18.9.0, coverlet 6.0.2 -> 6.0.4

CI debe pasar (build + test).